### PR TITLE
feat(auth): OAuth userinfo, refresh token, profile in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 Storefront UI. This repo targets **web only** (no mobile/desktop platforms in the tree).
 
+## Configuration (build-time)
+
+Переменные задаются через `--dart-define` (и при `flutter build web`):
+
+| Переменная | Назначение | Значение по умолчанию |
+|------------|------------|------------------------|
+| `AUTH_BASE_URL` | Базовый URL auth-сервиса (OAuth, userinfo, refresh) | `http://127.0.0.1:8000` |
+| `OAUTH_CLIENT_ID` | Публичный client_id для refresh_token и federated login | `zhuchka-market-web` |
+| `GOOGLE_CLIENT_ID` | Web client ID из Google Cloud (OAuth 2.0 → Web) | пусто |
+| `TELEGRAM_BOT_USERNAME` | Имя бота без `@` для Telegram Login (iframe) | пусто |
+
+Пример:
+
+```bash
+flutter run -d chrome --dart-define=AUTH_BASE_URL=https://auth.example.com --dart-define=GOOGLE_CLIENT_ID=xxx.apps.googleusercontent.com --dart-define=TELEGRAM_BOT_USERNAME=my_bot
+```
+
+Для Google Sign-In в `web/index.html` в мета-теге `google-signin-client_id` должен быть тот же Web client ID.
+
 ## Run (Chrome)
 
 ```bash

--- a/lib/auth/auth_api.dart
+++ b/lib/auth/auth_api.dart
@@ -4,13 +4,37 @@ import 'package:http/http.dart' as http;
 
 import '../config/app_config.dart';
 
-/// Calls Zhuchka auth-service federated endpoints.
+/// Calls Zhuchka auth-service (federated login, userinfo, refresh).
 class AuthApi {
   AuthApi({http.Client? httpClient}) : _http = httpClient ?? http.Client();
 
   final http.Client _http;
 
   Uri _u(String path) => Uri.parse('${AppConfig.authBaseUrl}$path');
+
+  Map<String, dynamic> _decodeJsonMap(http.Response res) {
+    final raw = res.body;
+    if (raw.isEmpty) {
+      return {};
+    }
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map<String, dynamic>) {
+      throw AuthApiException('Unexpected response', res.statusCode);
+    }
+    return decoded;
+  }
+
+  void _throwIfError(http.Response res, Map<String, dynamic> map) {
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      return;
+    }
+    final err = map['error']?.toString() ?? map['detail']?.toString() ?? 'error';
+    final desc = map['error_description']?.toString();
+    throw AuthApiException(
+      desc != null ? '$err: $desc' : err,
+      res.statusCode,
+    );
+  }
 
   Future<Map<String, dynamic>> postJson(
     String path,
@@ -21,15 +45,33 @@ class AuthApi {
       headers: {'Content-Type': 'application/json; charset=utf-8'},
       body: jsonEncode(body),
     );
-    final map = jsonDecode(res.body);
-    if (map is! Map<String, dynamic>) {
-      throw AuthApiException('Unexpected response', res.statusCode);
-    }
-    if (res.statusCode < 200 || res.statusCode >= 300) {
-      final err = map['error']?.toString() ?? 'error';
-      final desc = map['error_description']?.toString();
-      throw AuthApiException(desc != null ? '$err: $desc' : err, res.statusCode);
-    }
+    final map = _decodeJsonMap(res);
+    _throwIfError(res, map);
+    return map;
+  }
+
+  Future<Map<String, dynamic>> getUserInfo(String accessToken) async {
+    final res = await _http.get(
+      _u('/oauth/userinfo'),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+    final map = _decodeJsonMap(res);
+    _throwIfError(res, map);
+    return map;
+  }
+
+  /// OAuth2 form body (same as `curl -d grant_type=refresh_token ...`).
+  Future<Map<String, dynamic>> refreshWithRefreshToken(String refreshToken) async {
+    final res = await _http.post(
+      _u('/oauth/token'),
+      body: {
+        'grant_type': 'refresh_token',
+        'refresh_token': refreshToken,
+        'client_id': AppConfig.oauthPublicClientId,
+      },
+    );
+    final map = _decodeJsonMap(res);
+    _throwIfError(res, map);
     return map;
   }
 

--- a/lib/auth/auth_session.dart
+++ b/lib/auth/auth_session.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/foundation.dart';
+
+import 'auth_api.dart';
+import 'session_store.dart';
+
+/// Profile from `GET /oauth/userinfo`.
+class UserProfile {
+  const UserProfile({required this.sub, this.email});
+
+  final String sub;
+  final String? email;
+}
+
+/// Loads userinfo; on 401 tries `refresh_token` grant then retries once.
+class AuthSessionService {
+  AuthSessionService({AuthApi? api}) : _api = api ?? AuthApi();
+
+  final AuthApi _api;
+
+  Future<UserProfile?> loadProfile() async {
+    try {
+      if (!await SessionStore.hasAccessToken()) {
+        return null;
+      }
+      return await _loadWithRetry();
+    } catch (e, st) {
+      debugPrint('AuthSessionService.loadProfile: $e\n$st');
+      return null;
+    }
+  }
+
+  Future<UserProfile?> _loadWithRetry() async {
+    var access = await SessionStore.accessToken();
+    if (access == null) {
+      return null;
+    }
+    try {
+      return await _mapUserInfo(access);
+    } on AuthApiException catch (e) {
+      if (e.statusCode != 401) {
+        rethrow;
+      }
+      final refreshed = await _tryRefresh();
+      if (!refreshed) {
+        return null;
+      }
+      access = await SessionStore.accessToken();
+      if (access == null) {
+        return null;
+      }
+      return await _mapUserInfo(access);
+    }
+  }
+
+  Future<UserProfile?> _mapUserInfo(String access) async {
+    final m = await _api.getUserInfo(access);
+    return UserProfile(
+      sub: m['sub']?.toString() ?? '',
+      email: m['email']?.toString(),
+    );
+  }
+
+  Future<bool> _tryRefresh() async {
+    final refresh = await SessionStore.refreshToken();
+    if (refresh == null || refresh.isEmpty) {
+      await SessionStore.clear();
+      return false;
+    }
+    try {
+      final body = await _api.refreshWithRefreshToken(refresh);
+      await SessionStore.saveOAuthTokens(body);
+      return true;
+    } catch (e, st) {
+      debugPrint('refresh failed: $e\n$st');
+      await SessionStore.clear();
+      return false;
+    }
+  }
+
+  void dispose() => _api.dispose();
+}

--- a/lib/auth/session_store.dart
+++ b/lib/auth/session_store.dart
@@ -31,6 +31,11 @@ class SessionStore {
     return prefs.getString(_accessKey);
   }
 
+  static Future<String?> refreshToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_refreshKey);
+  }
+
   static Future<void> clear() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_accessKey);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'auth/auth_session.dart';
 import 'auth/session_store.dart';
 import 'widgets/auth_modal.dart';
 
@@ -32,8 +33,11 @@ class StorefrontHome extends StatefulWidget {
 }
 
 class _StorefrontHomeState extends State<StorefrontHome> {
+  final _authSession = AuthSessionService();
+
   bool _ready = false;
   bool _loggedIn = false;
+  String? _userEmail;
 
   @override
   void initState() {
@@ -41,12 +45,25 @@ class _StorefrontHomeState extends State<StorefrontHome> {
     _reloadSession();
   }
 
+  @override
+  void dispose() {
+    _authSession.dispose();
+    super.dispose();
+  }
+
   Future<void> _reloadSession() async {
-    final ok = await SessionStore.hasAccessToken();
+    var still = await SessionStore.hasAccessToken();
+    String? email;
+    if (still) {
+      final profile = await _authSession.loadProfile();
+      email = profile?.email;
+      still = await SessionStore.hasAccessToken();
+    }
     if (!mounted) return;
     setState(() {
-      _loggedIn = ok;
+      _loggedIn = still;
       _ready = true;
+      _userEmail = still ? email : null;
     });
   }
 
@@ -58,7 +75,10 @@ class _StorefrontHomeState extends State<StorefrontHome> {
   Future<void> _logout() async {
     await SessionStore.clear();
     if (!mounted) return;
-    setState(() => _loggedIn = false);
+    setState(() {
+      _loggedIn = false;
+      _userEmail = null;
+    });
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Вы вышли из аккаунта')),
     );
@@ -102,11 +122,19 @@ class _StorefrontHomeState extends State<StorefrontHome> {
                   style: Theme.of(context).textTheme.headlineMedium,
                   textAlign: TextAlign.center,
                 ),
+                if (_loggedIn && (_userEmail != null && _userEmail!.isNotEmpty)) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    _userEmail!,
+                    style: Theme.of(context).textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                ],
                 const SizedBox(height: 12),
                 Text(
                   _loggedIn
-                      ? 'Сессия сохранена локально (access / refresh token). Дальше — каталог и корзина.'
-                      : 'Нажмите «Войти» — модальное окно (не шторка). Google и Telegram при настройке auth.',
+                      ? 'Сессия: токены в локальном хранилище; профиль с auth-сервера (userinfo).'
+                      : 'Нажмите «Войти» — модальное окно. Google и Telegram при настройке auth.',
                   style: Theme.of(context).textTheme.bodyLarge,
                   textAlign: TextAlign.center,
                 ),


### PR DESCRIPTION
Adds client-side profile load via \GET /oauth/userinfo\, refresh via \POST /oauth/token\ (refresh_token grant), and shows email on the storefront when logged in. Documents \--dart-define\ variables in README.

**Changes**
- \AuthSessionService\: userinfo + 401 -> refresh + retry once
- \AuthApi\: \getUserInfo\, \efreshWithRefreshToken\
- \SessionStore.refreshToken\
- \main.dart\: session reload + profile, AppBar login/logout

Made with [Cursor](https://cursor.com)