### PR TITLE
ci: Flutter analyze, test, build web

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,0 +1,42 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [dev, master, main]
+  pull_request:
+    branches: [dev, master, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flutter-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-test-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Enable web
+        run: flutter config --enable-web
+
+      - name: Dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+      - name: Test
+        run: flutter test
+      - name: Build web (release)
+        run: flutter build web --release

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ Output: `build/web/`.
 ```bash
 flutter test
 ```
+
+## CI (GitHub Actions)
+
+On push/PR to `dev`, `main`, or `master`, `.github/workflows/flutter_ci.yml` runs `flutter analyze`, `flutter test`, and `flutter build web --release` on Ubuntu with the stable SDK.


### PR DESCRIPTION
Adds \.github/workflows/flutter_ci.yml\ (stable channel, web enabled): \lutter analyze\, \lutter test\, \lutter build web --release\ on push/PR to \dev\/\main\/\master\.

README: short CI section.

Addresses **#5**.

Made with [Cursor](https://cursor.com)