### PR TITLE
feat(theme): M3 OLED scaffold and surface tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Storefront UI. This repo targets **web only** (no mobile/desktop platforms in the tree).
 
+**UI spec:** [`docs/frontend-requirements.md`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docs/frontend-requirements.md) in the monorepo — Material 3, OLED scaffold `#000000`, shared tokens in `lib/theme/market_theme.dart` (`buildZhuchkaMarketTheme()`).
+
 ## Configuration (build-time)
 
 Переменные задаются через `--dart-define` (и при `flutter build web`):

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'auth/auth_session.dart';
 import 'auth/session_store.dart';
+import 'theme/market_theme.dart';
 import 'widgets/auth_modal.dart';
 
 void main() {
@@ -16,10 +17,8 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Zhuchka Market',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF2D2640)),
-        useMaterial3: true,
-      ),
+      themeMode: ThemeMode.dark,
+      theme: buildZhuchkaMarketTheme(),
       home: const StorefrontHome(),
     );
   }

--- a/lib/theme/market_theme.dart
+++ b/lib/theme/market_theme.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Accent seed for [ColorScheme] (Material 3 dark).
+///
+/// UI bar: [`docs/frontend-requirements.md`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docs/frontend-requirements.md)
+/// (OLED `#000000` scaffold, M3 surfaces).
+const Color kZhuchkaMarketBrandSeed = Color(0xFF2D2640);
+
+/// Project surface tokens layered on Material 3.
+@immutable
+class ZhuchkaMarketTokens extends ThemeExtension<ZhuchkaMarketTokens> {
+  const ZhuchkaMarketTokens({
+    this.oledBlack = const Color(0xFF000000),
+  });
+
+  /// Root scaffold / app background — strict OLED black (spec §2.1).
+  final Color oledBlack;
+
+  @override
+  ZhuchkaMarketTokens copyWith({Color? oledBlack}) {
+    return ZhuchkaMarketTokens(oledBlack: oledBlack ?? this.oledBlack);
+  }
+
+  @override
+  ZhuchkaMarketTokens lerp(ThemeExtension<ZhuchkaMarketTokens>? other, double t) {
+    if (other is! ZhuchkaMarketTokens) return this;
+    return ZhuchkaMarketTokens(
+      oledBlack: Color.lerp(oledBlack, other.oledBlack, t)!,
+    );
+  }
+}
+
+/// Dark-only storefront theme: M3, OLED black scaffold, generated [ColorScheme].
+ThemeData buildZhuchkaMarketTheme() {
+  final colorScheme = ColorScheme.fromSeed(
+    seedColor: kZhuchkaMarketBrandSeed,
+    brightness: Brightness.dark,
+  );
+
+  const tokens = ZhuchkaMarketTokens();
+
+  return ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    colorScheme: colorScheme,
+    scaffoldBackgroundColor: tokens.oledBlack,
+    extensions: const [tokens],
+    appBarTheme: AppBarTheme(
+      backgroundColor: colorScheme.surfaceContainerHighest,
+      surfaceTintColor: Colors.transparent,
+      foregroundColor: colorScheme.onSurface,
+    ),
+  );
+}

--- a/test/market_theme_test.dart
+++ b/test/market_theme_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:zhuchka_market/theme/market_theme.dart';
+
+void main() {
+  group('buildZhuchkaMarketTheme', () {
+    test('uses Material 3 and dark brightness', () {
+      final theme = buildZhuchkaMarketTheme();
+      expect(theme.useMaterial3, isTrue);
+      expect(theme.brightness, Brightness.dark);
+      expect(theme.colorScheme.brightness, Brightness.dark);
+    });
+
+    test('scaffold background is OLED black per frontend-requirements', () {
+      final theme = buildZhuchkaMarketTheme();
+      expect(theme.scaffoldBackgroundColor, const Color(0xFF000000));
+      final tokens = theme.extension<ZhuchkaMarketTokens>();
+      expect(tokens, isNotNull);
+      expect(tokens!.oledBlack, const Color(0xFF000000));
+    });
+
+    testWidgets('ThemeData drives scaffold background for Scaffold', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildZhuchkaMarketTheme(),
+          home: Builder(
+            builder: (context) {
+              expect(
+                Theme.of(context).scaffoldBackgroundColor,
+                const Color(0xFF000000),
+              );
+              return const Scaffold(body: SizedBox.shrink());
+            },
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements **#1**: Material 3 dark theme, OLED scaffold \#000000\, [ZhuchkaMarketTokens](lib/theme/market_theme.dart) ThemeExtension, AppBar without M3 surface tint noise.

## Tests
- \lutter analyze\ — clean
- \lutter test\ — \market_theme_test.dart\ + existing widget test

Closes #1

Made with [Cursor](https://cursor.com)