### PR TITLE
feat(routing): go_router shell (home, catalog, cart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Storefront UI. This repo targets **web only** (no mobile/desktop platforms in th
 
 **UI spec:** [`docs/frontend-requirements.md`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docs/frontend-requirements.md) in the monorepo — Material 3, OLED scaffold `#000000`, shared tokens in `lib/theme/market_theme.dart` (`buildZhuchkaMarketTheme()`).
 
+**Routing:** [`go_router`](https://pub.dev/packages/go_router) + shell (`lib/widgets/market_shell.dart`). Paths: `/` (витрина), `/catalog` и `/cart` — заглушки до backend (см. issue #7).
+
 ## Configuration (build-time)
 
 Переменные задаются через `--dart-define` (и при `flutter build web`):

--- a/lib/app/market_router.dart
+++ b/lib/app/market_router.dart
@@ -1,0 +1,37 @@
+import 'package:go_router/go_router.dart';
+
+import '../screens/cart_placeholder_screen.dart';
+import '../screens/catalog_placeholder_screen.dart';
+import '../screens/storefront_home_screen.dart';
+import '../widgets/market_shell.dart';
+
+/// Web routes: home, catalog/cart placeholders behind [MarketShell].
+GoRouter createMarketRouter() {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      ShellRoute(
+        builder: (context, state, child) {
+          return MarketShell(
+            location: state.uri.path,
+            child: child,
+          );
+        },
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const StorefrontHome(),
+          ),
+          GoRoute(
+            path: '/catalog',
+            builder: (context, state) => const CatalogPlaceholderScreen(),
+          ),
+          GoRoute(
+            path: '/cart',
+            builder: (context, state) => const CartPlaceholderScreen(),
+          ),
+        ],
+      ),
+    ],
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,154 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
-import 'auth/auth_session.dart';
-import 'auth/session_store.dart';
+import 'app/market_router.dart';
 import 'theme/market_theme.dart';
-import 'widgets/auth_modal.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
   @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  late final GoRouter _router = createMarketRouter();
+
+  @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Zhuchka Market',
       themeMode: ThemeMode.dark,
       theme: buildZhuchkaMarketTheme(),
-      home: const StorefrontHome(),
-    );
-  }
-}
-
-class StorefrontHome extends StatefulWidget {
-  const StorefrontHome({super.key});
-
-  @override
-  State<StorefrontHome> createState() => _StorefrontHomeState();
-}
-
-class _StorefrontHomeState extends State<StorefrontHome> {
-  final _authSession = AuthSessionService();
-
-  bool _ready = false;
-  bool _loggedIn = false;
-  String? _userEmail;
-
-  @override
-  void initState() {
-    super.initState();
-    _reloadSession();
-  }
-
-  @override
-  void dispose() {
-    _authSession.dispose();
-    super.dispose();
-  }
-
-  Future<void> _reloadSession() async {
-    var still = await SessionStore.hasAccessToken();
-    String? email;
-    if (still) {
-      final profile = await _authSession.loadProfile();
-      email = profile?.email;
-      still = await SessionStore.hasAccessToken();
-    }
-    if (!mounted) return;
-    setState(() {
-      _loggedIn = still;
-      _ready = true;
-      _userEmail = still ? email : null;
-    });
-  }
-
-  Future<void> _openAuth() async {
-    await showAuthModal(context);
-    await _reloadSession();
-  }
-
-  Future<void> _logout() async {
-    await SessionStore.clear();
-    if (!mounted) return;
-    setState(() {
-      _loggedIn = false;
-      _userEmail = null;
-    });
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Вы вышли из аккаунта')),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (!_ready) {
-      return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      );
-    }
-
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Zhuchka Market'),
-        actions: [
-          if (_loggedIn)
-            TextButton(
-              onPressed: _logout,
-              child: const Text('Выйти'),
-            )
-          else
-            TextButton(
-              onPressed: _openAuth,
-              child: const Text('Войти'),
-            ),
-          const SizedBox(width: 8),
-        ],
-      ),
-      body: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 560),
-          child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  'Витрина для покупателей',
-                  style: Theme.of(context).textTheme.headlineMedium,
-                  textAlign: TextAlign.center,
-                ),
-                if (_loggedIn && (_userEmail != null && _userEmail!.isNotEmpty)) ...[
-                  const SizedBox(height: 8),
-                  Text(
-                    _userEmail!,
-                    style: Theme.of(context).textTheme.titleMedium,
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-                const SizedBox(height: 12),
-                Text(
-                  _loggedIn
-                      ? 'Сессия: токены в локальном хранилище; профиль с auth-сервера (userinfo).'
-                      : 'Нажмите «Войти» — модальное окно. Google и Telegram при настройке auth.',
-                  style: Theme.of(context).textTheme.bodyLarge,
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 28),
-                if (!_loggedIn)
-                  FilledButton.icon(
-                    onPressed: _openAuth,
-                    icon: const Icon(Icons.login),
-                    label: const Text('Войти или зарегистрироваться'),
-                  ),
-              ],
-            ),
-          ),
-        ),
-      ),
+      routerConfig: _router,
     );
   }
 }

--- a/lib/screens/cart_placeholder_screen.dart
+++ b/lib/screens/cart_placeholder_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder until cart flow exists (issue #7).
+class CartPlaceholderScreen extends StatelessWidget {
+  const CartPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Корзина'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Корзина — заглушка. Список позиций появится после интеграции commerce.',
+            style: Theme.of(context).textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/catalog_placeholder_screen.dart
+++ b/lib/screens/catalog_placeholder_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder until catalog API is wired (issue #7).
+class CatalogPlaceholderScreen extends StatelessWidget {
+  const CatalogPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Каталог'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Раздел каталога — заглушка до подключения backend.',
+            style: Theme.of(context).textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/storefront_home_screen.dart
+++ b/lib/screens/storefront_home_screen.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+import '../auth/auth_session.dart';
+import '../auth/session_store.dart';
+import '../widgets/auth_modal.dart';
+
+/// Home / storefront landing (session, login CTA).
+class StorefrontHome extends StatefulWidget {
+  const StorefrontHome({super.key});
+
+  @override
+  State<StorefrontHome> createState() => _StorefrontHomeState();
+}
+
+class _StorefrontHomeState extends State<StorefrontHome> {
+  final _authSession = AuthSessionService();
+
+  bool _ready = false;
+  bool _loggedIn = false;
+  String? _userEmail;
+
+  @override
+  void initState() {
+    super.initState();
+    _reloadSession();
+  }
+
+  @override
+  void dispose() {
+    _authSession.dispose();
+    super.dispose();
+  }
+
+  Future<void> _reloadSession() async {
+    var still = await SessionStore.hasAccessToken();
+    String? email;
+    if (still) {
+      final profile = await _authSession.loadProfile();
+      email = profile?.email;
+      still = await SessionStore.hasAccessToken();
+    }
+    if (!mounted) return;
+    setState(() {
+      _loggedIn = still;
+      _ready = true;
+      _userEmail = still ? email : null;
+    });
+  }
+
+  Future<void> _openAuth() async {
+    await showAuthModal(context);
+    await _reloadSession();
+  }
+
+  Future<void> _logout() async {
+    await SessionStore.clear();
+    if (!mounted) return;
+    setState(() {
+      _loggedIn = false;
+      _userEmail = null;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Вы вышли из аккаунта')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_ready) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Zhuchka Market'),
+        actions: [
+          if (_loggedIn)
+            TextButton(
+              onPressed: _logout,
+              child: const Text('Выйти'),
+            )
+          else
+            TextButton(
+              onPressed: _openAuth,
+              child: const Text('Войти'),
+            ),
+          const SizedBox(width: 8),
+        ],
+      ),
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 560),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  'Витрина для покупателей',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                  textAlign: TextAlign.center,
+                ),
+                if (_loggedIn && (_userEmail != null && _userEmail!.isNotEmpty)) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    _userEmail!,
+                    style: Theme.of(context).textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+                const SizedBox(height: 12),
+                Text(
+                  _loggedIn
+                      ? 'Сессия: токены в локальном хранилище; профиль с auth-сервера (userinfo).'
+                      : 'Нажмите «Войти» — модальное окно. Google и Telegram при настройке auth.',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 28),
+                if (!_loggedIn)
+                  FilledButton.icon(
+                    onPressed: _openAuth,
+                    icon: const Icon(Icons.login),
+                    label: const Text('Войти или зарегистрироваться'),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/market_shell.dart
+++ b/lib/widgets/market_shell.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// App chrome: primary destinations + [child] from [GoRouter] [ShellRoute].
+class MarketShell extends StatelessWidget {
+  const MarketShell({
+    required this.location,
+    required this.child,
+    super.key,
+  });
+
+  final String location;
+  final Widget child;
+
+  int get _selectedIndex {
+    if (location.startsWith('/catalog')) return 1;
+    if (location.startsWith('/cart')) return 2;
+    return 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(child: child),
+        NavigationBar(
+          selectedIndex: _selectedIndex,
+          onDestinationSelected: (index) {
+            switch (index) {
+              case 0:
+                context.go('/');
+              case 1:
+                context.go('/catalog');
+              case 2:
+                context.go('/cart');
+            }
+          },
+          destinations: const [
+            NavigationDestination(
+              icon: Icon(Icons.home_outlined),
+              selectedIcon: Icon(Icons.home),
+              label: 'Главная',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.storefront_outlined),
+              selectedIcon: Icon(Icons.storefront),
+              label: 'Каталог',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.shopping_cart_outlined),
+              selectedIcon: Icon(Icons.shopping_cart),
+              label: 'Корзина',
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -96,6 +96,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.8.1"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -192,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  go_router: ^14.6.2
   http: ^1.2.2
   google_sign_in: ^6.2.2
   shared_preferences: ^2.3.3

--- a/test/router_shell_test.dart
+++ b/test/router_shell_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:zhuchka_market/main.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues({});
+
+  testWidgets('shell NavigationBar opens catalog placeholder', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+    expect(find.text('Витрина для покупателей'), findsOneWidget);
+
+    await tester.tap(find.text('Каталог'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Каталог'), findsWidgets);
+    expect(
+      find.text('Раздел каталога — заглушка до подключения backend.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shell NavigationBar opens cart placeholder', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Корзина'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Корзина'), findsWidgets);
+    expect(
+      find.textContaining('Корзина — заглушка'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('shell returns to home from catalog', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Каталог'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Главная'));
+    await tester.pumpAndSettle();
+    expect(find.text('Витрина для покупателей'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What
- **go_router** + \ShellRoute\: persistent \MarketShell\ with M3 \NavigationBar\ (Главная / Каталог / Корзина).
- Routes: \/\ → \StorefrontHome\, \/catalog\ and \/cart\ → placeholders (issue #7).
- \MaterialApp.router\ + \createMarketRouter()\ in \lib/app/market_router.dart\.

## Tests
\lutter analyze\ clean; \lutter test\ (existing + \outer_shell_test.dart\).

Closes #2

> **Note:** default branch of this repo is \master\; if GitHub does not auto-close #2 after merge to \dev\, close it manually.

Made with [Cursor](https://cursor.com)