### PR TITLE
feat(http): Dio, OAuth error mapping, GET retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Storefront UI. This repo targets **web only** (no mobile/desktop platforms in th
 
 **Routing:** [`go_router`](https://pub.dev/packages/go_router) + shell (`lib/widgets/market_shell.dart`). Paths: `/` (витрина), `/catalog` и `/cart` — заглушки до backend (см. issue #7).
 
+**HTTP:** [`dio`](https://pub.dev/packages/dio) — `createMarketDio()` (`lib/http/market_dio.dart`): таймауты, retry только для **GET** при сетевых сбоях (`RetryInterceptor`), ошибки OAuth → `AuthApiException` (`lib/http/dio_error_mapper.dart`). Прямые вызовы auth API — `AuthApi`.
+
 ## Configuration (build-time)
 
 Переменные задаются через `--dart-define` (и при `flutter build web`):

--- a/lib/auth/auth_api.dart
+++ b/lib/auth/auth_api.dart
@@ -1,38 +1,53 @@
 import 'dart:convert';
 
-import 'package:http/http.dart' as http;
+import 'package:dio/dio.dart';
 
 import '../config/app_config.dart';
+import '../http/dio_error_mapper.dart';
+import '../http/market_dio.dart';
+import 'auth_api_exception.dart';
 
-/// Calls Zhuchka auth-service (federated login, userinfo, refresh).
+export 'auth_api_exception.dart';
+
+/// Calls Zhuchka auth-service (federated login, userinfo, refresh) via [Dio].
 class AuthApi {
-  AuthApi({http.Client? httpClient}) : _http = httpClient ?? http.Client();
+  AuthApi({Dio? dio}) : _dio = dio ?? createMarketDio(), _ownsDio = dio == null;
 
-  final http.Client _http;
+  final Dio _dio;
+  final bool _ownsDio;
 
-  Uri _u(String path) => Uri.parse('${AppConfig.authBaseUrl}$path');
-
-  Map<String, dynamic> _decodeJsonMap(http.Response res) {
-    final raw = res.body;
-    if (raw.isEmpty) {
+  Map<String, dynamic> _decodeSuccess(Response<dynamic> res) {
+    final data = res.data;
+    if (data == null || data == '') {
       return {};
     }
-    final decoded = jsonDecode(raw);
-    if (decoded is! Map<String, dynamic>) {
-      throw AuthApiException('Unexpected response', res.statusCode);
+    if (data is Map<String, dynamic>) {
+      return data;
     }
-    return decoded;
+    if (data is Map) {
+      return Map<String, dynamic>.from(data);
+    }
+    if (data is String) {
+      final decoded = jsonDecode(data);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      if (decoded is Map) {
+        return Map<String, dynamic>.from(decoded);
+      }
+    }
+    throw AuthApiException('Unexpected response', res.statusCode ?? 0);
   }
 
-  void _throwIfError(http.Response res, Map<String, dynamic> map) {
-    if (res.statusCode >= 200 && res.statusCode < 300) {
+  void _throwIfError(int? statusCode, Map<String, dynamic> map) {
+    if (statusCode != null && statusCode >= 200 && statusCode < 300) {
       return;
     }
     final err = map['error']?.toString() ?? map['detail']?.toString() ?? 'error';
     final desc = map['error_description']?.toString();
     throw AuthApiException(
       desc != null ? '$err: $desc' : err,
-      res.statusCode,
+      statusCode ?? 0,
     );
   }
 
@@ -40,39 +55,57 @@ class AuthApi {
     String path,
     Map<String, dynamic> body,
   ) async {
-    final res = await _http.post(
-      _u(path),
-      headers: {'Content-Type': 'application/json; charset=utf-8'},
-      body: jsonEncode(body),
-    );
-    final map = _decodeJsonMap(res);
-    _throwIfError(res, map);
-    return map;
+    try {
+      final res = await _dio.post<dynamic>(
+        path,
+        data: body,
+        options: Options(
+          contentType: Headers.jsonContentType,
+          headers: {'Content-Type': 'application/json; charset=utf-8'},
+        ),
+      );
+      final map = _decodeSuccess(res);
+      _throwIfError(res.statusCode, map);
+      return map;
+    } on DioException catch (e) {
+      throw authApiExceptionFromDio(e);
+    }
   }
 
   Future<Map<String, dynamic>> getUserInfo(String accessToken) async {
-    final res = await _http.get(
-      _u('/oauth/userinfo'),
-      headers: {'Authorization': 'Bearer $accessToken'},
-    );
-    final map = _decodeJsonMap(res);
-    _throwIfError(res, map);
-    return map;
+    try {
+      final res = await _dio.get<dynamic>(
+        '/oauth/userinfo',
+        options: Options(
+          headers: {'Authorization': 'Bearer $accessToken'},
+        ),
+      );
+      final map = _decodeSuccess(res);
+      _throwIfError(res.statusCode, map);
+      return map;
+    } on DioException catch (e) {
+      throw authApiExceptionFromDio(e);
+    }
   }
 
   /// OAuth2 form body (same as `curl -d grant_type=refresh_token ...`).
   Future<Map<String, dynamic>> refreshWithRefreshToken(String refreshToken) async {
-    final res = await _http.post(
-      _u('/oauth/token'),
-      body: {
-        'grant_type': 'refresh_token',
-        'refresh_token': refreshToken,
-        'client_id': AppConfig.oauthPublicClientId,
-      },
-    );
-    final map = _decodeJsonMap(res);
-    _throwIfError(res, map);
-    return map;
+    try {
+      final res = await _dio.post<dynamic>(
+        '/oauth/token',
+        data: {
+          'grant_type': 'refresh_token',
+          'refresh_token': refreshToken,
+          'client_id': AppConfig.oauthPublicClientId,
+        },
+        options: Options(contentType: Headers.formUrlEncodedContentType),
+      );
+      final map = _decodeSuccess(res);
+      _throwIfError(res.statusCode, map);
+      return map;
+    } on DioException catch (e) {
+      throw authApiExceptionFromDio(e);
+    }
   }
 
   Future<Map<String, dynamic>> loginWithGoogleIdToken(String idToken) {
@@ -89,15 +122,9 @@ class AuthApi {
     });
   }
 
-  void dispose() => _http.close();
-}
-
-class AuthApiException implements Exception {
-  AuthApiException(this.message, this.statusCode);
-
-  final String message;
-  final int statusCode;
-
-  @override
-  String toString() => 'AuthApiException($statusCode): $message';
+  void dispose() {
+    if (_ownsDio) {
+      _dio.close();
+    }
+  }
 }

--- a/lib/auth/auth_api_exception.dart
+++ b/lib/auth/auth_api_exception.dart
@@ -1,0 +1,10 @@
+/// Error returned by auth-service HTTP layer (OAuth / userinfo / federated).
+class AuthApiException implements Exception {
+  AuthApiException(this.message, this.statusCode);
+
+  final String message;
+  final int statusCode;
+
+  @override
+  String toString() => 'AuthApiException($statusCode): $message';
+}

--- a/lib/http/dio_error_mapper.dart
+++ b/lib/http/dio_error_mapper.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+import '../auth/auth_api_exception.dart';
+
+/// Maps [DioException] to [AuthApiException] using OAuth-style JSON bodies when present.
+AuthApiException authApiExceptionFromDio(DioException e) {
+  final res = e.response;
+  if (res != null) {
+    final status = res.statusCode ?? 0;
+    final map = _tryJsonMap(res.data);
+    if (map.isNotEmpty) {
+      final err = map['error']?.toString() ?? map['detail']?.toString() ?? 'error';
+      final desc = map['error_description']?.toString();
+      return AuthApiException(
+        desc != null ? '$err: $desc' : err,
+        status,
+      );
+    }
+    return AuthApiException(e.message ?? 'error', status);
+  }
+  return AuthApiException(e.message ?? 'network error', 0);
+}
+
+Map<String, dynamic> _tryJsonMap(dynamic data) {
+  if (data is Map<String, dynamic>) {
+    return data;
+  }
+  if (data is Map) {
+    return Map<String, dynamic>.from(data);
+  }
+  if (data is String && data.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(data);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      if (decoded is Map) {
+        return Map<String, dynamic>.from(decoded);
+      }
+    } catch (_) {}
+  }
+  return {};
+}

--- a/lib/http/market_dio.dart
+++ b/lib/http/market_dio.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+
+import '../config/app_config.dart';
+import 'retry_interceptor.dart';
+
+/// Shared [Dio] for auth-service: timeouts, GET retries on transient failures.
+Dio createMarketDio() {
+  final base = AppConfig.authBaseUrl.replaceAll(RegExp(r'/+$'), '');
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: base,
+      connectTimeout: const Duration(seconds: 15),
+      receiveTimeout: const Duration(seconds: 30),
+      sendTimeout: const Duration(seconds: 30),
+    ),
+  );
+  dio.interceptors.add(RetryInterceptor(dio: dio));
+  return dio;
+}

--- a/lib/http/retry_interceptor.dart
+++ b/lib/http/retry_interceptor.dart
@@ -1,0 +1,52 @@
+import 'package:dio/dio.dart';
+
+/// Retries **GET** requests on transient network failures (timeouts, connection errors).
+///
+/// Mutating requests (POST, etc.) are not retried to avoid duplicate side effects.
+class RetryInterceptor extends Interceptor {
+  RetryInterceptor({required this.dio, this.maxRetries = 2});
+
+  final Dio dio;
+  final int maxRetries;
+
+  @override
+  Future<void> onError(
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) async {
+    if (err.requestOptions.method != 'GET') {
+      return handler.next(err);
+    }
+    if (!_isRetryable(err)) {
+      return handler.next(err);
+    }
+    final extra = err.requestOptions.extra;
+    final retry = (extra['retryCount'] as int?) ?? 0;
+    if (retry >= maxRetries) {
+      return handler.next(err);
+    }
+    extra['retryCount'] = retry + 1;
+    await Future<void>.delayed(Duration(milliseconds: 200 * (retry + 1)));
+    try {
+      final response = await dio.fetch<Object?>(err.requestOptions);
+      return handler.resolve(response);
+    } on DioException catch (e) {
+      return handler.next(e);
+    }
+  }
+
+  bool _isRetryable(DioException err) {
+    switch (err.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.connectionError:
+        return true;
+      case DioExceptionType.badResponse:
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.cancel:
+      case DioExceptionType.unknown:
+        return false;
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   fake_async:
     dependency: transitive
     description:
@@ -153,13 +169,21 @@ packages:
     source: hosted
     version: "0.12.4+4"
   http:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http_mock_adapter:
+    dependency: "direct dev"
+    description:
+      name: http_mock_adapter
+      sha256: "46399c78bd4a0af071978edd8c502d7aeeed73b5fb9860bca86b5ed647a63c1b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.1"
   http_parser:
     dependency: transitive
     description:
@@ -200,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   logging:
     dependency: transitive
     description:
@@ -232,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,8 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  dio: ^5.7.0
   go_router: ^14.6.2
-  http: ^1.2.2
   google_sign_in: ^6.2.2
   shared_preferences: ^2.3.3
 
@@ -49,6 +49,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
+  http_mock_adapter: ^0.6.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/auth/auth_api_dio_test.dart
+++ b/test/auth/auth_api_dio_test.dart
@@ -1,0 +1,55 @@
+import 'package:dio/dio.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:zhuchka_market/auth/auth_api.dart';
+
+void main() {
+  test('getUserInfo parses JSON success body', () async {
+    final dio = Dio(BaseOptions(baseUrl: 'http://mock.test'));
+    final adapter = DioAdapter(dio: dio);
+    dio.httpClientAdapter = adapter;
+
+    adapter.onGet(
+      '/oauth/userinfo',
+      (server) => server.reply(
+        200,
+        <String, dynamic>{
+          'sub': 'user-1',
+          'email': 'buyer@example.com',
+        },
+      ),
+    );
+
+    final api = AuthApi(dio: dio);
+    final map = await api.getUserInfo('access-token');
+    expect(map['sub'], 'user-1');
+    expect(map['email'], 'buyer@example.com');
+    api.dispose();
+  });
+
+  test('getUserInfo throws AuthApiException on 401 from mock', () async {
+    final dio = Dio(BaseOptions(baseUrl: 'http://mock.test'));
+    final adapter = DioAdapter(dio: dio);
+    dio.httpClientAdapter = adapter;
+
+    adapter.onGet(
+      '/oauth/userinfo',
+      (server) => server.reply(
+        401,
+        <String, dynamic>{
+          'error': 'invalid_token',
+        },
+      ),
+    );
+
+    final api = AuthApi(dio: dio);
+    await expectLater(
+      api.getUserInfo('bad'),
+      throwsA(
+        predicate<Object?>((e) => e is AuthApiException && e.statusCode == 401),
+      ),
+    );
+    api.dispose();
+  });
+}

--- a/test/http/dio_error_mapper_test.dart
+++ b/test/http/dio_error_mapper_test.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:zhuchka_market/http/dio_error_mapper.dart';
+
+void main() {
+  test('maps OAuth-style error body from badResponse', () {
+    final e = DioException(
+      requestOptions: RequestOptions(path: '/oauth/token'),
+      response: Response(
+        requestOptions: RequestOptions(path: '/oauth/token'),
+        statusCode: 401,
+        data: <String, dynamic>{
+          'error': 'invalid_grant',
+          'error_description': 'Refresh token expired',
+        },
+      ),
+      type: DioExceptionType.badResponse,
+    );
+    final ex = authApiExceptionFromDio(e);
+    expect(ex.statusCode, 401);
+    expect(ex.message, 'invalid_grant: Refresh token expired');
+  });
+
+  test('maps network error without response', () {
+    final e = DioException(
+      requestOptions: RequestOptions(path: '/x'),
+      type: DioExceptionType.connectionError,
+      message: 'Connection refused',
+    );
+    final ex = authApiExceptionFromDio(e);
+    expect(ex.statusCode, 0);
+    expect(ex.message, 'Connection refused');
+  });
+}


### PR DESCRIPTION
## Summary
- **Dio** (createMarketDio): timeouts, \RetryInterceptor\ for **GET** only (transient connection/timeout errors).
- **\uthApiExceptionFromDio\** for OAuth-style JSON error bodies.
- **\AuthApi\** migrated from \package:http\ to \Dio\; **\AuthApiException\** in \lib/auth/auth_api_exception.dart\.
- **Tests:** \dio_error_mapper_test.dart\, \uth_api_dio_test.dart\ (http_mock_adapter), existing suite green.

## Commands
\lutter analyze\, \lutter test\

Closes #3

> Merge when ready; after merge bump \rontend/market\ in monorepo (see \docs/git-workflow.md\).

Made with [Cursor](https://cursor.com)