### PR TITLE
feat(ui): loading, empty, and error views (issue #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Storefront UI. This repo targets **web only** (no mobile/desktop platforms in th
 
 **HTTP:** [`dio`](https://pub.dev/packages/dio) — `createMarketDio()` (`lib/http/market_dio.dart`): таймауты, retry только для **GET** при сетевых сбоях (`RetryInterceptor`), ошибки OAuth → `AuthApiException` (`lib/http/dio_error_mapper.dart`). Прямые вызовы auth API — `AuthApi`.
 
+**Состояния UI (loading / empty / error):** `lib/widgets/market_async_views.dart` — `MarketLoadingView`, `MarketEmptyView`, `MarketErrorView` (см. `docs/frontend-requirements.md` §5).
+
 ## Configuration (build-time)
 
 Переменные задаются через `--dart-define` (и при `flutter build web`):

--- a/lib/screens/cart_placeholder_screen.dart
+++ b/lib/screens/cart_placeholder_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/market_async_views.dart';
+
 /// Placeholder until cart flow exists (issue #7).
 class CartPlaceholderScreen extends StatelessWidget {
   const CartPlaceholderScreen({super.key});
@@ -10,15 +12,11 @@ class CartPlaceholderScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Корзина'),
       ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(
-            'Корзина — заглушка. Список позиций появится после интеграции commerce.',
-            style: Theme.of(context).textTheme.bodyLarge,
-            textAlign: TextAlign.center,
-          ),
-        ),
+      body: const MarketEmptyView(
+        icon: Icons.shopping_cart_outlined,
+        title: 'Корзина пуста',
+        message:
+            'Список позиций появится после интеграции commerce backend (issue #7).',
       ),
     );
   }

--- a/lib/screens/catalog_placeholder_screen.dart
+++ b/lib/screens/catalog_placeholder_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/market_async_views.dart';
+
 /// Placeholder until catalog API is wired (issue #7).
 class CatalogPlaceholderScreen extends StatelessWidget {
   const CatalogPlaceholderScreen({super.key});
@@ -10,15 +12,11 @@ class CatalogPlaceholderScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Каталог'),
       ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(
-            'Раздел каталога — заглушка до подключения backend.',
-            style: Theme.of(context).textTheme.bodyLarge,
-            textAlign: TextAlign.center,
-          ),
-        ),
+      body: const MarketEmptyView(
+        icon: Icons.storefront_outlined,
+        title: 'Каталог скоро здесь',
+        message:
+            'Раздел каталога — заглушка до подключения backend API (см. issue #7).',
       ),
     );
   }

--- a/lib/screens/storefront_home_screen.dart
+++ b/lib/screens/storefront_home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../auth/auth_session.dart';
 import '../auth/session_store.dart';
 import '../widgets/auth_modal.dart';
+import '../widgets/market_async_views.dart';
 
 /// Home / storefront landing (session, login CTA).
 class StorefrontHome extends StatefulWidget {
@@ -68,7 +69,7 @@ class _StorefrontHomeState extends State<StorefrontHome> {
   Widget build(BuildContext context) {
     if (!_ready) {
       return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
+        body: MarketLoadingView(message: 'Загрузка сессии…'),
       );
     }
 

--- a/lib/widgets/market_async_views.dart
+++ b/lib/widgets/market_async_views.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+
+/// Full-screen or in-body loading indicator with optional caption (M3, accessible).
+class MarketLoadingView extends StatelessWidget {
+  const MarketLoadingView({
+    this.message,
+    super.key,
+  });
+
+  final String? message;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Center(
+      child: Semantics(
+        label: message ?? 'Загрузка',
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const CircularProgressIndicator(),
+            if (message != null) ...[
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                child: Text(
+                  message!,
+                  style: textTheme.bodyMedium,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Empty state: icon, title, body, optional primary action (see `docs/frontend-requirements.md` §5.3).
+class MarketEmptyView extends StatelessWidget {
+  const MarketEmptyView({
+    required this.icon,
+    required this.title,
+    required this.message,
+    this.actionLabel,
+    this.onAction,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final String message;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Semantics(
+            container: true,
+            label: '$title. $message',
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, size: 56, color: colorScheme.primary),
+                const SizedBox(height: 16),
+                Text(
+                  title,
+                  style: textTheme.titleLarge,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  message,
+                  style: textTheme.bodyLarge,
+                  textAlign: TextAlign.center,
+                ),
+                if (actionLabel != null && onAction != null) ...[
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: onAction,
+                    child: Text(actionLabel!),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Recoverable error surface with optional retry (§5.3).
+class MarketErrorView extends StatelessWidget {
+  const MarketErrorView({
+    required this.message,
+    this.onRetry,
+    this.retryLabel = 'Повторить',
+    super.key,
+  });
+
+  final String message;
+  final VoidCallback? onRetry;
+  final String retryLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 400),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Semantics(
+            container: true,
+            label: 'Ошибка. $message',
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.error_outline, size: 56, color: colorScheme.error),
+                const SizedBox(height: 16),
+                Text(
+                  'Что-то пошло не так',
+                  style: textTheme.titleLarge,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  message,
+                  style: textTheme.bodyLarge,
+                  textAlign: TextAlign.center,
+                ),
+                if (onRetry != null) ...[
+                  const SizedBox(height: 24),
+                  FilledButton.tonal(
+                    onPressed: onRetry,
+                    child: Text(retryLabel),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/router_shell_test.dart
+++ b/test/router_shell_test.dart
@@ -16,8 +16,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Каталог'), findsWidgets);
+    expect(find.text('Каталог скоро здесь'), findsOneWidget);
     expect(
-      find.text('Раздел каталога — заглушка до подключения backend.'),
+      find.textContaining('backend API'),
       findsOneWidget,
     );
   });
@@ -30,8 +31,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Корзина'), findsWidgets);
+    expect(find.text('Корзина пуста'), findsOneWidget);
     expect(
-      find.textContaining('Корзина — заглушка'),
+      find.textContaining('commerce backend'),
       findsOneWidget,
     );
   });

--- a/test/widgets/market_async_views_test.dart
+++ b/test/widgets/market_async_views_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:zhuchka_market/theme/market_theme.dart';
+import 'package:zhuchka_market/widgets/market_async_views.dart';
+
+void main() {
+  group('MarketLoadingView', () {
+    testWidgets('shows progress indicator', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildZhuchkaMarketTheme(),
+          home: const Scaffold(body: MarketLoadingView()),
+        ),
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows message when provided', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildZhuchkaMarketTheme(),
+          home: const Scaffold(
+            body: MarketLoadingView(message: 'Загрузка теста'),
+          ),
+        ),
+      );
+      expect(find.text('Загрузка теста'), findsOneWidget);
+    });
+  });
+
+  group('MarketEmptyView', () {
+    testWidgets('renders title and message', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildZhuchkaMarketTheme(),
+          home: const Scaffold(
+            body: MarketEmptyView(
+              icon: Icons.inbox_outlined,
+              title: 'Пусто',
+              message: 'Нет данных',
+            ),
+          ),
+        ),
+      );
+      expect(find.text('Пусто'), findsOneWidget);
+      expect(find.text('Нет данных'), findsOneWidget);
+    });
+
+    testWidgets('renders action when callback set', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildZhuchkaMarketTheme(),
+          home: Scaffold(
+            body: MarketEmptyView(
+              icon: Icons.inbox_outlined,
+              title: 'Пусто',
+              message: 'Нет данных',
+              actionLabel: 'Обновить',
+              onAction: () => tapped = true,
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Обновить'));
+      expect(tapped, isTrue);
+    });
+  });
+
+  group('MarketErrorView', () {
+    testWidgets('shows message and retry', (tester) async {
+      var retries = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildZhuchkaMarketTheme(),
+          home: Scaffold(
+            body: MarketErrorView(
+              message: 'Сеть недоступна',
+              onRetry: () => retries++,
+            ),
+          ),
+        ),
+      );
+      expect(find.text('Сеть недоступна'), findsOneWidget);
+      await tester.tap(find.text('Повторить'));
+      expect(retries, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Commits (atomic)
1. \eat(ui): add MarketLoadingView, MarketEmptyView, MarketErrorView\
2. \eat(home): MarketLoadingView while session hydrates\
3. \eat(placeholders): MarketEmptyView on catalog and cart screens\
4. \	est(ui): widget tests for MarketLoadingView, EmptyView, ErrorView\
5. \	est(router): expect catalog/cart empty-state copy\
6. \docs(readme): document async state widgets (issue #9)\

## Tests
\lutter analyze\, \lutter test\ — green.

Closes #9

> После merge — отдельный bump \rontend/market\ в монорепо (\docs/git-workflow.md\).

Made with [Cursor](https://cursor.com)